### PR TITLE
Added tree-based collectives profiling

### DIFF
--- a/src/plugins/mpi/pmix/pmixp_dconn_ucx.c
+++ b/src/plugins/mpi/pmix/pmixp_dconn_ucx.c
@@ -850,7 +850,11 @@ static void _ucx_regio(eio_handle_t *h)
 {
 	eio_obj_t *obj;
 
-	pipe(_service_pipe);
+	if (pipe(_service_pipe) < 0) {
+		fatal("pipe: %m");
+		// TODO: propagate the error to an upper layer
+		return;
+	}
 	fd_set_nonblocking(_service_pipe[0]);
 	fd_set_nonblocking(_service_pipe[1]);
 	fd_set_close_on_exec(_service_pipe[0]);


### PR DESCRIPTION
- Added tree collectives profiling 
- Logging as `error` log-level, if` debug` is not enabled