### PR TITLE
mpi/pmix: PMIx_Abort minor fixes

### DIFF
--- a/src/plugins/mpi/pmix/mpi_pmix.c
+++ b/src/plugins/mpi/pmix/mpi_pmix.c
@@ -9,7 +9,6 @@
  *                          All rights reserved.
  *  Written by Boris Bochkarev <boris-bochkaryov@yandex.ru>.
  *
- *
  *  This file is part of Slurm, a resource management program.
  *  For details, see <https://slurm.schedmd.com/>.
  *  Please also read the included file: DISCLAIMER.

--- a/src/plugins/mpi/pmix/pmixp_agent.c
+++ b/src/plugins/mpi/pmix/pmixp_agent.c
@@ -74,6 +74,7 @@ static bool _conn_readable(eio_obj_t *obj);
 static int _server_conn_read(eio_obj_t *obj, List objs);
 static int _timer_conn_read(eio_obj_t *obj, List objs);
 static int _abort_conn_read(eio_obj_t *obj, List objs);
+
 static struct io_operations abort_ops = {
 	.readable = &_conn_readable,
 	.handle_read = &_abort_conn_read
@@ -160,32 +161,44 @@ static int _abort_conn_read(eio_obj_t *obj, List objs)
 	int abort_client_sock;
 	uint32_t ret_status;
 	int shutdown = 0;
+	int len;
 
 	while (1) {
 		if (!pmixp_fd_read_ready(obj->fd, &shutdown)) {
 			if (shutdown) {
 				obj->shutdown = true;
 				if (shutdown < 0)
-					PMIXP_ERROR_NO(shutdown, "sd=%d failure", obj->fd);
+					PMIXP_ERROR_NO(shutdown,
+						       "sd=%d failure",
+						       obj->fd);
 			}
 			return SLURM_SUCCESS;
 		}
 
-		if ((abort_client_sock = slurm_accept_msg_conn(obj->fd, &abort_client)) < 0) {
-			PMIXP_ERROR("Error accept %s", strerror(errno));
+		if ((abort_client_sock =
+			 slurm_accept_msg_conn(obj->fd, &abort_client)) < 0) {
+			PMIXP_ERROR("slurm_accept_msg_conn: %m");
 			return SLURM_ERROR;
 		}
-		PMIXP_DEBUG("New abort client: %s:%d", inet_ntoa(abort_client.sin_addr), abort_client.sin_port);
+		PMIXP_DEBUG("New abort client: %s:%d",
+			    inet_ntoa(abort_client.sin_addr),
+			    abort_client.sin_port);
 
-		int len;
-		if ((len = slurm_read_stream(abort_client_sock, (char*)&ret_status, sizeof(ret_status))) == -1)
+		if ((len = slurm_read_stream(abort_client_sock,
+					     (char*)&ret_status,
+					     sizeof(ret_status))) == -1) {
 			return SLURM_ERROR;
+		}
 
-		if ((len = slurm_write_stream(abort_client_sock, (char*)&ret_status, sizeof(ret_status))) == -1)
+		if ((len = slurm_write_stream(abort_client_sock,
+					      (char*)&ret_status,
+					      sizeof(ret_status))) == -1) {
 			return SLURM_ERROR;
+		}
 
-		if (SLURM_SUCCESS == pmixp_info_abort_status())
+		if (!pmixp_info_abort_status()) {
 			pmixp_info_set_abort_status((int)ntohl(ret_status));
+		}
 
 		close(abort_client_sock);
 	}
@@ -354,25 +367,35 @@ static void *_pmix_abort_thread(void *args)
 
 int pmixp_abort_agent_start(char ***env)
 {
+	char ip_str[INET6_ADDRSTRLEN];
 	int abort_server_socket = -1;
+	slurm_addr_t abort_server;
+	eio_obj_t *obj;
+
 	if ((abort_server_socket = slurm_init_msg_engine_port(0)) < 0) {
-		PMIXP_ERROR("Error slurm_open_stream %s", strerror(errno));
-		return SLURM_COMMUNICATIONS_CONNECTION_ERROR;
+		PMIXP_ERROR("slurm_init_msg_engine_port: %m");
+		return SLURM_ERROR;
 	}
 
-	slurm_addr_t abort_server;
 	memset(&abort_server, 0, sizeof(slurm_addr_t));
 
-	slurm_get_stream_addr(abort_server_socket, &abort_server);
-	PMIXP_DEBUG("Abort server ip:port: %s:%d", inet_ntoa(abort_server.sin_addr), abort_server.sin_port);
+	if (slurm_get_stream_addr(abort_server_socket, &abort_server)) {
+		PMIXP_ERROR("slurm_get_stream_addr error %m");
+		return SLURM_ERROR;
+	}
+	PMIXP_DEBUG("Abort server ip:port: %s:%d",
+		    inet_ntoa(abort_server.sin_addr),
+		    abort_server.sin_port);
 
-	char ip_buffer[INET_ADDRSTRLEN];
-	inet_ntop(AF_INET, &abort_server.sin_addr, ip_buffer, sizeof(ip_buffer)); // TODO: check error return
+	if (inet_ntop(AF_INET, &abort_server.sin_addr, ip_str, INET6_ADDRSTRLEN)
+			== NULL) {
+		PMIXP_ERROR("inet_ntop failed");
+		return SLURM_ERROR;
+	}
 
-	setenvf(env, PMIXP_SLURM_ABORT_AGENT_IP, "%s", ip_buffer);
+	setenvf(env, PMIXP_SLURM_ABORT_AGENT_IP, "%s", ip_str);
 	setenvf(env, PMIXP_SLURM_ABORT_AGENT_PORT, "%d", abort_server.sin_port);
 
-	eio_obj_t *obj;
 	_abort_handle = eio_handle_create(0);
 	obj = eio_obj_create(abort_server_socket, &abort_ops, (void *)(-1));
 	eio_new_initial_obj(_abort_handle, obj);

--- a/src/plugins/mpi/pmix/pmixp_client.c
+++ b/src/plugins/mpi/pmix/pmixp_client.c
@@ -795,8 +795,6 @@ error:
 	return SLURM_ERROR;
 }
 
-
-
 extern int pmixp_lib_abort(const pmixp_proc_t *proc, void *server_object,
 			   int status, const char msg[],
 			   pmixp_proc_t procs[], size_t nprocs,
@@ -804,24 +802,28 @@ extern int pmixp_lib_abort(const pmixp_proc_t *proc, void *server_object,
 {
 	pmix_op_cbfunc_t abort_cbfunc = (pmix_op_cbfunc_t)cbfunc;
 	uint32_t status_net = htonl((uint32_t)status);
-
+	int len;
+	int client_sock;
 	slurm_addr_t abort_server;
+
 	abort_server.sin_family = AF_INET;
 	abort_server.sin_port = pmixp_info_abort_agent_port();
 	abort_server.sin_addr.s_addr = inet_addr(pmixp_info_srun_ip());
 
-	int client_sock;
 	if((client_sock = slurm_open_msg_conn(&abort_server)) < 0){
-		PMIXP_ERROR("Error create and conn client socket: %s", strerror(errno));
+		PMIXP_ERROR("slurm_open_msg_conn: %m");
 		return SLURM_ERROR;
 	}
 
-	int len;
-	if ((len = slurm_write_stream(client_sock, (char*)&status_net, sizeof(status_net))) == -1)
+	if ((len = slurm_write_stream(client_sock, (char*)&status_net,
+				      sizeof(status_net))) == -1) {
 		return SLURM_ERROR;
+	}
 
-	if ((len = slurm_read_stream(client_sock, (char*)&status_net, sizeof(status_net))) == -1)
+	if ((len = slurm_read_stream(client_sock, (char*)&status_net,
+				     sizeof(status_net))) == -1) {
 		return SLURM_ERROR;
+	}
 
 	close(client_sock);
 

--- a/src/plugins/mpi/pmix/pmixp_info.c
+++ b/src/plugins/mpi/pmix/pmixp_info.c
@@ -216,6 +216,10 @@ int pmixp_info_free(void)
 		xfree(_pmixp_job_info.task_map_packed);
 	}
 
+	if (_pmixp_job_info.srun_ip) {
+		xfree(_pmixp_job_info.srun_ip);
+	}
+
 	hostlist_destroy(_pmixp_job_info.job_hl);
 	hostlist_destroy(_pmixp_job_info.step_hl);
 	if (_pmixp_job_info.hostname) {
@@ -300,19 +304,20 @@ static int _resources_set(char ***env)
 {
 	char *p = NULL;
 
+	/* Initialize abort thread info */
 	p = getenvp(*env, PMIXP_SLURM_ABORT_AGENT_IP);
-	if (NULL != p) {
+	if (!p) {
 		_pmixp_job_info.srun_ip = xstrdup(p);
 	} else {
 		_pmixp_job_info.srun_ip = NULL;
 	}
-
 	p = getenvp(*env, PMIXP_SLURM_ABORT_AGENT_PORT);
-	if (NULL != p) {
-		_pmixp_job_info.abort_agent_port = atoi(xstrdup(p));
+	if (!p) {
+		_pmixp_job_info.abort_agent_port = atoi(p);
 	} else {
 		_pmixp_job_info.abort_agent_port = -1;
 	}
+	_pmixp_job_info.abort_status = 0;
 
 	/* Initialize all memory pointers that would be allocated to NULL
 	 * So in case of error exit we will know what to xfree
@@ -382,6 +387,9 @@ err_exit:
 	hostlist_destroy(_pmixp_job_info.step_hl);
 	if (_pmixp_job_info.hostname) {
 		xfree(_pmixp_job_info.hostname);
+	}
+	if (_pmixp_job_info.srun_ip) {
+		xfree(_pmixp_job_info.srun_ip);
 	}
 	return SLURM_ERROR;
 }

--- a/src/plugins/mpi/pmix/pmixp_info.h
+++ b/src/plugins/mpi/pmix/pmixp_info.h
@@ -76,7 +76,7 @@ typedef struct {
 	char *spool_dir;
 	uid_t uid;
 	gid_t gid;
-	char* srun_ip;
+	char *srun_ip;
 	int abort_agent_port;
 	int abort_status;
 } pmix_jobinfo_t;


### PR DESCRIPTION
Testing is not finished. Found a problem:
```bash
srun -N2  --mpi=pmix -vvv hostname
...
srun: debug:  (null) [0] pmixp_agent.c:388 [pmixp_abort_agent_start] mpi/pmix: Abort server ip:port: 0.0.0.0:22423
...
```
Due to `srun` gets `0.0.0.0` IP address it propagates the zero-IP to stepdaemons which cannot connect on this IP.